### PR TITLE
ProcString fix +2

### DIFF
--- a/SpellGUIV2/MainWindow.xaml.cs
+++ b/SpellGUIV2/MainWindow.xaml.cs
@@ -372,9 +372,9 @@ namespace SpellEditor
                     targetBoxes.Add(box);
                 }
 
-                string[] proc_strings = { "None", "Any Hostile Action", "On Gain Experience", "On Melee Attack", "On Crit Hit Victim", "On Cast Spell", "On Physical Attack Victim", "On Ranged Attack", "On Ranged Crit Attack", "On Physical Attack", "On Melee Attack Victim", "On Spell Hit", "On Ranged Crit Attack Victim", "On Crit Attack", "On Ranged Attack Victim", "On Pre Dispell Aura Victim", "On Spell Land Victim", "On Cast Specific Spell", "On Spell Hit Victim", "On Spell Crit Hit Victim", "On Target Death", "On Any Damage Victim", "On Trap Trigger", "On Auto Shot Hit", "On Absorb", "On Resist Victim", "On Dodge Victim", "On Death", "Remove On Use", "Misc", "On Block Victim", "On Spell Crit Hit" };
-
-                for (int i = 0; i < proc_strings.Length; ++i)
+				string[] proc_strings = { "None", "On Death", "On Target Killed (yielding XP or Honor)", "On Melee Attack Done", "On Melee Attack Received", "Physical Ability Damage Done", "On Physical Ability Damage Taken", "On Ranged Autoattack Done", "On Ranged Autoattack Taken", "On Ranged Ability Damage Done", "On Ranged Ability Damage Taken", "On Positive Spell Damage Done (Class NONE) HEAL??", "On Positive Spell Damage Taken (Class NONE) HEAL??", "On Spell Damage Done (Class NONE)", "On Spell Damage Received (Class NONE)", "On Positive Spell Damage Done (MAGIC)", "On Positive Spell Damage Taken (MAGIC)", "On Spell Damage Done (MAGIC)", "On Spell Damage Received (MAGIC)", "On Periodic Effect Done (Damage/heal)", "On Periodic Effect Taken (Damage/heal)", "On Any Damage Taken", "On Trap Trigger", "On Mainhand Autoattack Hit", "On Offhand Autoattack Hit", "On Death" };
+				// modified proc_strings according to https://wowdev.wiki/DB/Spell : 3.3.5.12340 -> procFlags
+				for (int i = 0; i < proc_strings.Length; ++i)
                 {
                     ThreadSafeCheckBox box = new ThreadSafeCheckBox();
 

--- a/SpellGUIV2/Sources/DBC/SpellIconDBC.cs
+++ b/SpellGUIV2/Sources/DBC/SpellIconDBC.cs
@@ -94,7 +94,7 @@ namespace SpellEditor.Sources.DBC
 
         public async void UpdateMainWindowIcons(double margin)
         {
-			if (adapter == null) {
+			if (adapter == null || main.selectedID == 0) { // adapter.query below caused unhandled exception with main.selectedID as 0.
                 return;
             }
 

--- a/SpellGUIV2/Sources/Tools/SpellFamilyClassMaskParser/spellFamilyClassMaskParser.cs
+++ b/SpellGUIV2/Sources/Tools/SpellFamilyClassMaskParser/spellFamilyClassMaskParser.cs
@@ -16,7 +16,8 @@ namespace SpellEditor.Sources.Tools.SpellFamilyClassMaskStoreParser
 	{
 		public SpellFamilyClassMaskParser(MainWindow window)
 		{
-			spellFamilyClassMaskStore = new ArrayList[18, 3, 32];
+			spellFamilyClassMaskStore = new ArrayList[100, 3, 32]; // 18 -> 100 : I'm testing if we can create new spellfamilies just
+																	// by giving it some unique id for procces on our own spells
 
 			DataTable dt = window.GetDBAdapter().query(string.Format("SELECT id,SpellFamilyName,SpellFamilyFlags,SpellFamilyFlags1,SpellFamilyFlags2 FROM {0}",window.GetConfig().Table));
 


### PR DESCRIPTION
And also one little issue with accessing spell 0's icon causes empty row and thus unhandled exception (at least here it did).
The last change of dimensions on that array were only to allow people to use custom SpellFamilyNames for their own spells (which must still be <= 100), like creating a proc that ONLY fires on a custom ability.
Cheers.