### PR TITLE
Improve export/import reliability and MPQ workflow.

### DIFF
--- a/SpellGUIV2/ImportExportWindow.xaml
+++ b/SpellGUIV2/ImportExportWindow.xaml
@@ -1,4 +1,4 @@
-﻿<controls:MetroWindow
+<controls:MetroWindow
         x:Class="SpellEditor.ImportExportWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -67,18 +67,22 @@
                         <RowDefinition Height="AUTO"/>
                         <RowDefinition Height="AUTO"/>
                         <RowDefinition Height="AUTO"/>
+                        <RowDefinition Height="AUTO"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Button Name="ExportClickBtn1" Content="{DynamicResource ExportCheckedFiles}" Margin="10" Click="ExportClick" Grid.Row="0" Grid.Column="0"/>
                     <Button Name="ExportClickBtn2" Content="{DynamicResource ExportCheckedFilesMpq}" Margin="10" Click="MpqClick" Grid.Row="0" Grid.Column="1"/>
                     <Label Content="{DynamicResource ExportMpqName}" HorizontalAlignment="Right" Margin="5" Grid.Row="1" Grid.Column="0"/>
                     <TextBox Name="ExportMpqNameTxt" Text="patch-4.mpq" Margin="10,5,10,5" Grid.Row="1" Grid.Column="1"/>
-                    <Label Content="{DynamicResource TablesToExport}" Margin="5" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"/>
+                    <Label Content="Custom MPQ copy folder:" HorizontalAlignment="Right" Margin="5" Grid.Row="2" Grid.Column="0"/>
+                    <TextBox Name="CustomMpqCopyDirectoryTxt" Margin="10,5,10,5" MinWidth="240" Grid.Row="2" Grid.Column="1" LostFocus="CustomMpqCopyDirectoryTxt_LostFocus"/>
+                    <Button Name="CustomMpqCopyBrowseBtn" Content="Browse..." Margin="10,5,10,5" Grid.Row="2" Grid.Column="2" Click="CustomMpqCopyBrowseBtn_Click"/>
+                    <Label Content="{DynamicResource TablesToExport}" Margin="5" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"/>
                     <Label Name="ExportLoadedCount" Margin="5" Grid.Row="0" Grid.Column="2" VerticalAlignment="Center"/>
                     <CheckBox Name="ExportSelectAll" Content="Select All" Margin="5" Grid.Row="0" Grid.Column="3" Checked="SelectAllChanged" Unchecked="SelectAllChanged"/>
                     <Label Content="Export Type:"  Margin="5" Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"/>
                     <ComboBox Name="ExportTypeCombo" Margin="5" Grid.Row="1" Grid.Column="3"/>
-                    <ScrollViewer Grid.Row="3" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="4" MinWidth="500">
+                    <ScrollViewer Grid.Row="4" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="4" MinWidth="500">
                         <UniformGrid Name="ExportGridDbcs" Columns="2"/>
                     </ScrollViewer>
                 </Grid>

--- a/SpellGUIV2/ImportExportWindow.xaml.cs
+++ b/SpellGUIV2/ImportExportWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -56,6 +56,7 @@ namespace SpellEditor
             Application.Current.DispatcherUnhandledException += App_DispatcherUnhandledException;
             BuildImportExportTab();
             ExportMpqNameTxt.Text = string.IsNullOrEmpty(Config.DefaultMpqName) ? "patch-4.MPQ" : Config.DefaultMpqName;
+            CustomMpqCopyDirectoryTxt.Text = Config.CustomMpqCopyDirectory ?? string.Empty;
         }
 
         private bool IsDefaultImport(string name)
@@ -185,11 +186,18 @@ namespace SpellEditor
             var archiveName = ExportMpqNameTxt.Text.Length > 0 ? ExportMpqNameTxt.Text : "empty.mpq";
             archiveName = archiveName.ToLower().EndsWith(".mpq") ? archiveName : archiveName + ".MPQ";
             _MpqArchiveName = archiveName;
+            Config.DefaultMpqName = archiveName;
+            Config.CustomMpqCopyDirectory = CustomMpqCopyDirectoryTxt.Text?.Trim() ?? string.Empty;
             ClickHandler(false);
         }
 
         private void ImportClick(object sender, RoutedEventArgs e) => ClickHandler(true);
-        private void ExportClick(object sender, RoutedEventArgs e) => ClickHandler(false);
+        private void ExportClick(object sender, RoutedEventArgs e)
+        {
+            // Ensure plain export does not trigger MPQ creation.
+            _MpqArchiveName = string.Empty;
+            ClickHandler(false);
+        }
         private void ClickHandler(bool isImport)
         {
             ImportExportType useType;
@@ -239,6 +247,10 @@ namespace SpellEditor
 
         private void doImportExport(bool isImport, List<string> bindingList, ImportExportType useType)
         {
+            // Capture MPQ target name for this run to avoid cross-click state bleed.
+            var mpqArchiveName = _MpqArchiveName;
+            var isMpqExportRun = !isImport && !string.IsNullOrEmpty(mpqArchiveName);
+            var selectedBindingsForRun = new List<string>(bindingList);
             var barLookup = new Dictionary<string, ProgressBar>();
             bindingList.ForEach(bindingName => barLookup.Add(bindingName, LookupProgressBar(bindingName, isImport)));
 
@@ -246,13 +258,13 @@ namespace SpellEditor
 
             Task.Run(() =>
             {
-                var bag = new ConcurrentBag<Task>();
-                var adapters = new List<IDatabaseAdapter>();
-                bool isSpellImport = bindingList.Contains(_SpellBindingName);
-                var adapterIndex = isSpellImport ? 1 : 0;
-
                 try
                 {
+                    var bag = new ConcurrentBag<Task>();
+                    var adapters = new List<IDatabaseAdapter>();
+                    bool isSpellImport = bindingList.Contains(_SpellBindingName);
+                    var adapterIndex = isSpellImport ? 1 : 0;
+
                     // Start spell export immediately if it is selected
                     if (bindingList.Contains(_SpellBindingName))
                     {
@@ -310,47 +322,105 @@ namespace SpellEditor
                         }
                         Dispatcher.InvokeAsync(new Action(() => label.Content = $"Remaining: {allTasks.Count}"));
                     }
-                }
-                finally
-                {
+
                     adapters.ForEach(adapter => adapter.Dispose());
                     adapters.Clear();
-                }
 
-                // Create MPQ if required
-                if (!string.IsNullOrEmpty(_MpqArchiveName))
-                {
-                    var exportList = new List<string>();
-                    Directory.EnumerateFiles("Export")
-                        .Where((dbcFile) => dbcFile.EndsWith(".dbc"))
-                        .ToList()
-                        .ForEach(exportList.Add);
-                    var mpqExport = new MpqExport();
-                    mpqExport.CreateMpqFromDbcFileList(_MpqArchiveName, exportList);
-                }
-
-                // Reset
-                Dispatcher.InvokeAsync(new Action(() =>
-                {
-                    _TaskLookup.Values.ToList().ForEach(bar =>
+                    // Create MPQ if required
+                    if (isMpqExportRun)
                     {
-                        bar.Value = 0;
-                        bar.Visibility = Visibility.Hidden;
-                    });
-                    ImportClickBtn.IsEnabled = true;
-                    ExportClickBtn1.IsEnabled = true;
-                    ExportClickBtn2.IsEnabled = true;
-                    _TaskLookup = new ConcurrentDictionary<int, ProgressBar>();
-                }));
+                        var exportList = selectedBindingsForRun
+                            .Select(bindingName => Path.Combine("Export", bindingName + ".dbc"))
+                            .Where(File.Exists)
+                            .ToList();
 
-                // Refresh spell selection list on import
-                if (isImport)
-                {
+                        var mpqExport = new MpqExport();
+                        mpqExport.CreateMpqFromDbcFileList(mpqArchiveName, exportList);
+
+                        var customCopyDirectory = Config.CustomMpqCopyDirectory?.Trim();
+                        if (!string.IsNullOrEmpty(customCopyDirectory))
+                        {
+                            if (!Directory.Exists(customCopyDirectory))
+                            {
+                                ShowFlyoutMessage($"Custom MPQ copy folder does not exist: {customCopyDirectory}");
+                            }
+                            else
+                            {
+                                var sourceMpqPath = Path.Combine("Export", mpqArchiveName);
+                                var destinationMpqPath = Path.Combine(customCopyDirectory, mpqArchiveName);
+                                try
+                                {
+                                    File.Copy(sourceMpqPath, destinationMpqPath, true);
+                                }
+                                catch (Exception exception)
+                                {
+                                    Logger.Info($"ERROR: Failed to copy MPQ to custom folder {customCopyDirectory}: {exception.Message}\n{exception}\n{exception.InnerException}");
+                                    ShowFlyoutMessage($"Failed to copy MPQ to custom folder: {customCopyDirectory}");
+                                }
+                            }
+                        }
+
+                        // MPQ mode should not leave DBC artifacts behind.
+                        foreach (var exportedDbc in exportList)
+                        {
+                            try
+                            {
+                                if (File.Exists(exportedDbc))
+                                {
+                                    File.Delete(exportedDbc);
+                                }
+                            }
+                            catch (Exception exception)
+                            {
+                                Logger.Info($"ERROR: Failed to clean exported DBC artifact {exportedDbc}: {exception.Message}\n{exception}\n{exception.InnerException}");
+                            }
+                        }
+                    }
+                    // Reset
                     Dispatcher.InvokeAsync(new Action(() =>
                     {
-                        _ReloadData.Invoke(null);
-                        _PopulateSelectSpell.Invoke();
-                        Close();
+                        try
+                        {
+                            // Always re-enable buttons even if some progress bars are missing.
+                            ImportClickBtn.IsEnabled = true;
+                            ExportClickBtn1.IsEnabled = true;
+                            ExportClickBtn2.IsEnabled = true;
+
+                            _TaskLookup.Values.ToList().ForEach(bar =>
+                            {
+                                if (bar == null)
+                                    return;
+                                bar.Value = 0;
+                                bar.Visibility = Visibility.Hidden;
+                            });
+                            _TaskLookup = new ConcurrentDictionary<int, ProgressBar>();
+                        }
+                        catch (Exception exception)
+                        {
+                            Logger.Info($"ERROR: Failed to reset import/export UI state: {exception.Message}\n{exception}\n{exception.InnerException}");
+                        }
+                    }));
+
+                    // Refresh spell selection list on import
+                    if (isImport)
+                    {
+                        Dispatcher.InvokeAsync(new Action(() =>
+                        {
+                            _ReloadData.Invoke(null);
+                            _PopulateSelectSpell.Invoke();
+                            Close();
+                        }));
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Logger.Info($"ERROR: Import/Export worker failed: {exception.Message}\n{exception}\n{exception.InnerException}");
+                    ShowFlyoutMessage("Import/Export failed. Check log output for details.");
+                    Dispatcher.InvokeAsync(new Action(() =>
+                    {
+                        ImportClickBtn.IsEnabled = true;
+                        ExportClickBtn1.IsEnabled = true;
+                        ExportClickBtn2.IsEnabled = true;
                     }));
                 }
             });
@@ -446,6 +516,30 @@ namespace SpellEditor
                 Flyout.IsOpen = true;
                 FlyoutText.Text = message;
             }));
+        }
+
+        private void CustomMpqCopyBrowseBtn_Click(object sender, RoutedEventArgs e)
+        {
+            using (var dialog = new System.Windows.Forms.FolderBrowserDialog())
+            {
+                dialog.RootFolder = Environment.SpecialFolder.MyComputer;
+                var currentPath = CustomMpqCopyDirectoryTxt.Text?.Trim();
+                if (!string.IsNullOrEmpty(currentPath) && Directory.Exists(currentPath))
+                {
+                    dialog.SelectedPath = currentPath;
+                }
+
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    CustomMpqCopyDirectoryTxt.Text = dialog.SelectedPath;
+                    Config.CustomMpqCopyDirectory = dialog.SelectedPath;
+                }
+            }
+        }
+
+        private void CustomMpqCopyDirectoryTxt_LostFocus(object sender, RoutedEventArgs e)
+        {
+            Config.CustomMpqCopyDirectory = CustomMpqCopyDirectoryTxt.Text?.Trim() ?? string.Empty;
         }
 
         private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/SpellGUIV2/MainWindow.xaml.cs
+++ b/SpellGUIV2/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -2518,6 +2518,12 @@ namespace SpellEditor
 
                         var labels = ConvertBoxListToLabelsWithIds(dynamicDbcInstance.GetAllBoxes());
 
+                        if (labels == null || labels.Count == 0)
+                        {
+                            currContentControl.Content = new ThreadSafeTextBox { TextWrapping = TextWrapping.Wrap };
+                            continue;
+                        }
+
                         // verify first line has index, expected format : "420 - text"
                         if (!Regex.IsMatch(labels[0].ToString(), @"^\d+ -"))
                             throw new Exception($"DBC ressource for misc value type {currMiscValue.ToString()} (xkey:{ressource_string_name}) doesn't use expected indexing format.");
@@ -3007,8 +3013,8 @@ namespace SpellEditor
 
                 updateProgress("Updating category & dispel & mechanic...");
                 var loadCategories = (SpellCategory)DBCManager.GetInstance().FindDbcForBinding("SpellCategory");
-                Category.ThreadSafeIndex = loadCategories.UpdateCategorySelection(uint.Parse(
-                    adapter.Query($"SELECT `Category` FROM `{"spell"}` WHERE `ID` = '{selectedID}'").Rows[0][0].ToString()));
+                var categoryRows = adapter.Query($"SELECT `Category` FROM `{"spell"}` WHERE `ID` = '{selectedID}'").Rows;
+                Category.ThreadSafeIndex = loadCategories.UpdateCategorySelection(uint.Parse(categoryRows[0][0].ToString()));
 
                 var loadDispels = (SpellDispelType)DBCManager.GetInstance().FindDbcForBinding("SpellDispelType");
                 DispelType.ThreadSafeIndex = loadDispels.UpdateDispelSelection(uint.Parse(
@@ -3559,8 +3565,9 @@ namespace SpellEditor
                     updateProgress("Updating spell description variables & difficulty selection...");
                     var loadDifficulties = (SpellDifficulty)DBCManager.GetInstance().FindDbcForBinding("SpellDifficulty");
                     var loadDescriptionVariables = (SpellDescriptionVariables)DBCManager.GetInstance().FindDbcForBinding("SpellDescriptionVariables");
+                    var descriptionRows = adapter.Query($"SELECT `SpellDescriptionVariableID` FROM `{"spell"}` WHERE `ID` = '{selectedID}'").Rows;
                     SpellDescriptionVariables.ThreadSafeIndex = loadDescriptionVariables.UpdateSpellDescriptionVariablesSelection(
-                        uint.Parse(adapter.Query($"SELECT `SpellDescriptionVariableID` FROM `{"spell"}` WHERE `ID` = '{selectedID}'").Rows[0][0].ToString()));
+                        uint.Parse(descriptionRows[0][0].ToString()));
 
                     Difficulty.ThreadSafeIndex = loadDifficulties.UpdateDifficultySelection(uint.Parse(adapter.Query(
                         $"SELECT `SpellDifficultyID` FROM `{"spell"}` WHERE `ID` = '{selectedID}'").Rows[0][0].ToString()));

--- a/SpellGUIV2/Sources/Config/Config.cs
+++ b/SpellGUIV2/Sources/Config/Config.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+using NLog;
 using SpellEditor.Sources.VersionControl;
 using System;
 using System.IO;
@@ -145,6 +145,16 @@ namespace SpellEditor.Sources.Config
             set
             {
                 UpdateConfigValue("DefaultMpqName", value);
+                Save();
+            }
+        }
+
+        public static string CustomMpqCopyDirectory
+        {
+            get { return GetConfigValue("CustomMpqCopyDirectory"); }
+            set
+            {
+                UpdateConfigValue("CustomMpqCopyDirectory", value);
                 Save();
             }
         }

--- a/SpellGUIV2/Sources/Controls/SpellSelectList/RelayCommand.cs
+++ b/SpellGUIV2/Sources/Controls/SpellSelectList/RelayCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 
 namespace SpellEditor
@@ -9,7 +9,11 @@ namespace SpellEditor
 
         public RelayCommand(Action<object> execute) => _execute = execute;
 
-        public event EventHandler CanExecuteChanged;
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
 
         public bool CanExecute(object parameter) => true;
 

--- a/SpellGUIV2/Sources/Controls/SpellSelectList/SpellSelectionList.cs
+++ b/SpellGUIV2/Sources/Controls/SpellSelectList/SpellSelectionList.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+using NLog;
 using SpellEditor.Sources.Controls.Common;
 using SpellEditor.Sources.Controls.SpellSelectList;
 using SpellEditor.Sources.Database;

--- a/SpellGUIV2/Sources/Tools/MPQ/MpqExport.cs
+++ b/SpellGUIV2/Sources/Tools/MPQ/MpqExport.cs
@@ -1,15 +1,48 @@
-﻿using StormLibSharp;
+using StormLibSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace SpellEditor.Sources.Tools.MPQ
 {
     class MpqExport
     {
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr LoadLibrary(string lpFileName);
+
+        private static void EnsureStormLibAvailable()
+        {
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var arch = Environment.Is64BitProcess ? "x64" : "x86";
+            var rootDll = Path.Combine(baseDir, "stormlib.dll");
+            var outputArchDll = Path.Combine(baseDir, arch, "StormLib.dll");
+            var repoArchDll = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "stormlibsharp", "lib", arch, "rel", "StormLib.dll"));
+
+            if (!File.Exists(rootDll))
+            {
+                if (File.Exists(outputArchDll))
+                {
+                    File.Copy(outputArchDll, rootDll, true);
+                }
+                else if (File.Exists(repoArchDll))
+                {
+                    File.Copy(repoArchDll, rootDll, true);
+                }
+            }
+
+            var loadResult = LoadLibrary(rootDll);
+
+            if (loadResult == IntPtr.Zero)
+            {
+                throw new DllNotFoundException($"StormLib native DLL could not be loaded from {rootDll}");
+            }
+        }
+
         public void CreateMpqFromDbcFileList(string archiveName, List<string> exportList)
         {
+            EnsureStormLibAvailable();
             var archivePath = "Export\\" + archiveName;
             if (File.Exists(archivePath))
             {

--- a/SpellGUIV2/SpellEditor.csproj
+++ b/SpellGUIV2/SpellEditor.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Costura.Fody.6.0.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.6.0.0\build\Costura.Fody.props')" />
   <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" />
@@ -158,9 +158,6 @@
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
@@ -363,6 +360,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\stormlibsharp\lib\x64\rel\StormLib.dll">
+      <Link>x64\StormLib.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\stormlibsharp\lib\x86\rel\StormLib.dll">
+      <Link>x86\StormLib.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Resource Include="icon.ico" />

--- a/SpellGUIV2/packages.config
+++ b/SpellGUIV2/packages.config
@@ -1,6 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle" version="1.8.9" targetFramework="net452" />
   <package id="ControlzEx" version="4.4.0" targetFramework="net48" />
   <package id="Costura.Fody" version="6.0.0" targetFramework="net48" developmentDependency="true" />
   <package id="EntityFramework" version="6.4.4" targetFramework="net452" />


### PR DESCRIPTION
Fix multiple high-impact issues in the spell editor workflow: prevent crashes when misc-value DBC label sources are empty, ensure export buttons recover from MPQ creation failures, and separate DBC-only export from MPQ export behavior. Add robust MPQ native DLL loading/copy support (x86/x64), include native StormLib binaries in build output, and add a persisted custom MPQ copy destination in the Export UI so MPQs can be mirrored to a user-defined folder.

Also clean up build-time and dependency quality issues by removing an unused vulnerable BouncyCastle package reference, resolving duplicate Unsafe assembly references, and wiring RelayCommand.CanExecuteChanged to CommandManager to eliminate stale ICommand warnings. Keep MPQ-mode output focused by packaging selected DBCs into MPQ and cleaning temporary DBC artifacts afterward.

Made-with: Cursor